### PR TITLE
Docs + Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,11 @@ Wraps an `async` function so that it will be attempted `limit` times before it a
 
 **TODO:** At present this function fires of the original function as soon as the previous attempt failed - it should ideally support a linear and incremental backoff (ie. allowing it to wait *x* milliseconds before making another attempt)- and the simplest way to allow for this would be to make it accept a **curve** function and **increments** as params.
 
+Where the wrapped function rejects multiple times (exceeding the limit), the error that it finally rejects with will always be value that the last attempt rejected with.
+
 - **fn** - (`Function`) - an `async` function to be wrapped for retrying.
 - **limit** - (`Number`) - the number of times to retry - defaults to `2`.
-- **retried** - (`Function`) - the wrapped function.
+- **retrier** - (`Function`) - the wrapped function.
 
 ### clock(*fn*, *[concurrency = 1]*) => *clocked*
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raywhite/async-hofs",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Async / Promise related higher order functions and utils",
   "main": "./src/index.js",
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -75,12 +75,12 @@ module.exports.createRetrierFn = function (fn, limit = 2) {
    */
   return function (arg) {
     return new Promise(function (resolve, reject) {
-      const recurse = function (err, r) {
-        if (!r) return reject(err)
+      const recurse = function (err, remaining) {
+        if (remaining === 0) return reject(err)
         try {
-          return fn(arg).then(resolve).catch(e => recurse(e, r - 1))
-        } catch (serr) { // NOTE: Some sync error.
-          return reject(serr)
+          return fn(arg).then(resolve).catch(asyncErr => recurse(asyncErr, remaining - 1))
+        } catch (syncErr) { // NOTE: Some sync error.
+          return reject(syncErr)
         }
       }
 


### PR DESCRIPTION
It seems logical that the retried should actually return an array of errors when it
rejects, although this is almost never going to be useful and will break some
userland code in other places