### PR TITLE
Allow variable argument functions to be used with createRetrierFn

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,6 +19,8 @@
         "no-plusplus": 0,
         "no-loop-func": 0,
         "semi": [2, "never"],
-        "no-await-in-loop": 0
+        "no-await-in-loop": 0,
+        "prefer-rest-params": 0,
+        "prefer-spread": 0
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -74,12 +74,15 @@ module.exports.createRetrierFn = function (fn, limit = 2) {
    * @param {...Mixed}
    * @returns {Mixed}
    */
-  return function (arg) {
+  return function () {
+    const args = [].slice.call(arguments)
     return new Promise(function (resolve, reject) {
       const recurse = function (err, remaining) {
         if (remaining === 0) return reject(err)
         try {
-          return fn(arg).then(resolve).catch(asyncErr => recurse(asyncErr, remaining - 1))
+          return fn.apply(null, args)
+            .then(resolve)
+            .catch(asyncErr => recurse(asyncErr, remaining - 1))
         } catch (syncErr) { // NOTE: Some sync error.
           return reject(syncErr)
         }


### PR DESCRIPTION
Also adjust linting rules, which require some usages which are not node
6 compatible.